### PR TITLE
fix Xdebug with docker 18.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,9 +134,10 @@ RUN cd /opt \
 && touch /etc/php-7.0.d/90-xdebug.ini \
 && echo "[xdebug]" > /etc/php-7.0.d/90-xdebug.ini \
 && echo "zend_extension = /usr/lib64/php/7.0/modules/xdebug.so" >> /etc/php-7.0.d/90-xdebug.ini \
-&& echo "xdebug.idekey=PHPSTORM" >> /etc/php-7.0.d/90-xdebug.ini \
 && echo "xdebug.remote_enable=true" >> /etc/php-7.0.d/90-xdebug.ini \
-&& echo "xdebug.remote_host=dockerhost" >> /etc/php-7.0.d/90-xdebug.ini \
+&& echo "xdebug.remote_autostart=true" >> /etc/php-7.0.d/90-xdebug.ini \
+&& echo "xdebug.remote_host=host.docker.internal" >> /etc/php-7.0.d/90-xdebug.ini \
+# Ajout depuis docker 18.3 : host.docker.internal pointe vers le host
 && cd .. \
 && rm xdebug-2.5.4.tgz \
 && rm -R xdebug-2.5.4 \
@@ -154,6 +155,7 @@ COPY config/.bashrc /root/
 RUN touch /etc/version \
 && echo "Current image version : 0.6" > /etc/version \
 && echo "---------- Version history ----------" >> /etc/version \
+&& echo "0.7 - Finalisation de la Configuration XDebug" >> /etc/version \
 && echo "0.6 - Ajout patch et diffutils" >> /etc/version \
 && echo "0.5 - Ajustements Xdebug" >> /etc/version \
 && echo "0.4 - Optimisation du shell" >> /etc/version \

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ Soumettre l'image
 $ ./push.sh
 ````
 
-Historique des versions : **dernière version -> 0.6**
+Historique des versions : **dernière version -> 0.7**
 
 | Version | Description                 |
 | :-----: | --------------------------- |
+| 0.7     | Finalisation XDebug         |
 | 0.6     | Ajout patch et diffutils    |
 | 0.5     | Ajustements Xdebug          |
 | 0.4     | Optimisation du shell       |

--- a/myproject/docker-compose.yml
+++ b/myproject/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./runtime/vhosts.conf.d:/etc/httpd/vhosts.conf.d
       - ./runtime/mysql:/var/lib/mysql
       - ./runtime/log:/var/log/httpd
+      - ./runtime/php/99-myXdebug.ini:/etc/php-7.0.d/99-myXdebug.ini
       - ./runtime/scripts:/opt/scripts
       - ./runtime/web:/var/www/html
       - ./runtime/conf/.mybashrc:/root/.mybashrc
@@ -14,6 +15,3 @@ services:
       - 9080:80
       - 3306:3306
     env_file: ./my_project.env
-    extra_hosts:
-    # export DOCKERHOST=$(ifconfig | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk '{ print $2 }' | cut -f2 -d: | head -n1)
-      - "dockerhost:$DOCKERHOST"

--- a/myproject/runtime/php/99-myXdebug.ini
+++ b/myproject/runtime/php/99-myXdebug.ini
@@ -1,0 +1,2 @@
+[xdebug]
+xdebug.idekey=PHPSTORM


### PR DESCRIPTION
2 objectifs : 
1- retirer le "dockerhost" qui n'est plus pertinant
2- permettre aux dev de modifier la clef de Xdebug en fonction de leur projet