### PR TITLE
Correction Contenaire Ubuntu

### DIFF
--- a/ubuntu-php7/Dockerfile
+++ b/ubuntu-php7/Dockerfile
@@ -8,9 +8,10 @@ RUN apt-get install -y \
     curl \
     gcc \
     ghostscript \
+    git \
     unzip \
     vim \
-    zip
+    zip 
 
 #
 # Time zone

--- a/ubuntu-php7/Dockerfile
+++ b/ubuntu-php7/Dockerfile
@@ -92,13 +92,14 @@ RUN cd /opt \
     && tar -xvzf xdebug-2.9.0.tgz \
     && cd /opt/xdebug-2.9.0 \
     && phpize \
+    && export PHP_API_VERSION=$(php -i | grep 'PHP API' | sed -e 's/PHP API => //') \
     && ./configure \
     && make \
     && make test \
     && make install \
     && touch /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \
     && echo "[xdebug]" > /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \
-    && echo "zend_extension = /usr/lib/php/20180731/xdebug.so" >> /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \
+    && echo "zend_extension = /usr/lib/php/$PHP_API_VERSION/xdebug.so" >> /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \
     && echo "xdebug.remote_enable=true" >> /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \
     && echo "xdebug.remote_autostart=true" >> /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \
     && echo "xdebug.remote_host=host.docker.internal" >> /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \

--- a/ubuntu-php7/Dockerfile
+++ b/ubuntu-php7/Dockerfile
@@ -98,7 +98,7 @@ RUN cd /opt \
     && make install \
     && touch /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \
     && echo "[xdebug]" > /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \
-    && echo "zend_extension = /usr/lib64/php/$PHP_VERSION/modules/xdebug.so" >> /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \
+    && echo "zend_extension = /usr/lib/php/20180731/xdebug.so" >> /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \
     && echo "xdebug.remote_enable=true" >> /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \
     && echo "xdebug.remote_autostart=true" >> /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \
     && echo "xdebug.remote_host=host.docker.internal" >> /etc/php/$PHP_VERSION/apache2/conf.d/90-xdebug.ini \

--- a/ubuntu-php7/myproject/docker-compose.yml
+++ b/ubuntu-php7/myproject/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./runtime/conf/default_vhost.conf:/etc/apache2/sites-available/000-default.conf
       - ./runtime/log:/var/log/httpd
-      - ./runtime/php/99-myXdebug.ini:/etc/php-7.3.d/99-myXdebug.ini
+      - ./runtime/php/99-myXdebug.ini:/etc/php/7.3/apache2/conf.d/99-myXdebug.ini
       - ./runtime/scripts:/opt/scripts
       - ./runtime/web:/var/www/html
       - ./runtime/conf/.mybashrc:/opt/.mybashrc:delegated

--- a/ubuntu-php7/myproject/docker-compose.yml
+++ b/ubuntu-php7/myproject/docker-compose.yml
@@ -4,11 +4,12 @@ services:
     container_name: myproject-web
     image: eurelis/ubuntu-php7
     volumes:
+      - ./runtime/conf/default_vhost.conf:/etc/apache2/sites-available/000-default.conf
       - ./runtime/log:/var/log/httpd
       - ./runtime/php/99-myXdebug.ini:/etc/php-7.3.d/99-myXdebug.ini
       - ./runtime/scripts:/opt/scripts
       - ./runtime/web:/var/www/html
-      # - ./runtime/conf/.mybashrc:/opt/.mybashrc
+      - ./runtime/conf/.mybashrc:/opt/.mybashrc:delegated
     ports:
       - 9080:80
     env_file: ./my_project.env

--- a/ubuntu-php7/myproject/runtime/conf/default_vhost.conf
+++ b/ubuntu-php7/myproject/runtime/conf/default_vhost.conf
@@ -1,0 +1,19 @@
+<VirtualHost *:80>
+	ServerAdmin support@eurelis.com
+	ServerName localhost
+	DocumentRoot /var/www/html/web
+
+	LogLevel warn
+	ErrorLog /var/log/httpd/error.log
+	CustomLog /var/log/httpd/access.log combined
+
+	<Directory /var/www/html>
+	  Require all granted
+		Options FollowSymLinks MultiViews
+		AllowOverride All
+
+		#Order deny,allow
+		#Allow from all
+	</Directory>
+
+</VirtualHost>

--- a/ubuntu-php7/myproject/runtime/php/99-myXdebug.ini
+++ b/ubuntu-php7/myproject/runtime/php/99-myXdebug.ini
@@ -1,2 +1,9 @@
 [xdebug]
 xdebug.idekey=PHPSTORM
+
+# VScode
+# 
+# xdebug.remote_host="${WSL_HOST_IP}"
+
+# PHPSTORM
+# // Rien a faire


### PR DESCRIPTION
Liste des modifications : 
- Ajout de git dans les logiciels
- Ajout d'une config par défaut pour le vhost apache
- Ajout du 99-MyXdebug avec infos de config VScode VS Phpstorm
- Variabilisation de la lib Xdebug (*)

* : Xdebug est déposé dans le dossier /usr/lib/php/[VERSION API PHP]/
hors cette "version d'api" correspond à une date lié à l'exécutable php (20190902 pour php7.4 VS 20180731 pour php 7.3).
J'ai donc du "retrouver" cette valeur pour compléter le chemin "proprement" pour que la lib soit bien activée